### PR TITLE
Added changes and improvements

### DIFF
--- a/src/index.did
+++ b/src/index.did
@@ -1,5 +1,4 @@
 type UserProfile = record {
-  id : text;
   bio : text;
   username : text;
   createdAt : nat64;
@@ -12,10 +11,10 @@ type _AzleResult = variant { Ok : UserProfile; Err : text };
 type _AzleResult_1 = variant { Ok : vec UserProfile; Err : text };
 service : () -> {
   createUserProfile : (UserProfilePayload) -> (_AzleResult);
-  deleteUserProfile : (text) -> (_AzleResult);
-  followProfile : (text, text) -> (_AzleResult);
+  deleteUserProfile : () -> (_AzleResult);
+  followProfile : (text) -> (_AzleResult);
   getUserProfile : (text) -> (_AzleResult) query;
   getUserProfiles : () -> (_AzleResult_1) query;
-  unfollowProfile : (text, text) -> (_AzleResult);
-  updateUserProfile : (text, UserProfilePayload) -> (_AzleResult);
+  unfollowProfile : (text) -> (_AzleResult);
+  updateUserProfile : (UserProfilePayload) -> (_AzleResult);
 }


### PR DESCRIPTION
- Modified the `userStorageProfile` map to use Principal IDs as the keys. This brings in a unique way to let users create accounts using their Principal IDs, which is a unique way to identify users on the Internet Computer
- Modified the `createUserProfile` function to only restrict any user with the anonymous Principal ID `2vxsx-fae` from creating an account. This ensures that every user has a valid and unique principal ID before creating an account.

- Modified the `deleteUserProfile` and `updateUserProfile` functions to allow only the owner of the account to delete and update the accpunt respectively. this brings in some sort of decentralization where a user has full control over their information
- Modified the `unfollowProfile` and `followProfile` functions to implement the new logic of Principal IDs for identifying user accounts
